### PR TITLE
fix: load template from file instead of passing a string

### DIFF
--- a/terraform/main/main.tf
+++ b/terraform/main/main.tf
@@ -26,10 +26,9 @@ provider "aws" {
   region  = var.region
 }
 
-data "template_file" "template_lambda"{
-  template = "test.sh"
-
-  vars     = {
+data "template_file" "template_lambda" {
+  template = file("${path.module}/test.sh.tpl")
+  vars = {
     lambda_name = var.lambda_name
   }
 }

--- a/terraform/main/test.sh.tpl
+++ b/terraform/main/test.sh.tpl
@@ -1,0 +1,3 @@
+#!/usr/bin/bash
+
+echo "El nombre de la lambda es:"


### PR DESCRIPTION
Use the function file to load the content of the test.ssh.tpl. 